### PR TITLE
Add support for Schoology LMS

### DIFF
--- a/src/Commands/AddLti1p3Platform.php
+++ b/src/Commands/AddLti1p3Platform.php
@@ -50,6 +50,7 @@ class AddLti1p3Platform extends Command
             $this->warn("  lms_type can be one of:");
             $this->warn("    * 'canvas-cloud' - Cloud-hosted instances of Canvas LMS");
             $this->warn("    * 'moodle' - Moodle");
+            $this->warn("    * 'schoology' - Schoology");
             $this->warn("    * 'custom' - Any other LMS.");
             $this->warn('See https://github.com/longhornopen/laravel-celtic-lti/wiki/LTI-Key-Generation for the locations of the client and deployment IDs in your LMS.');
             return 0;
@@ -82,6 +83,15 @@ class AddLti1p3Platform extends Command
                 $client_id,
                 $platform_id
             );
+            $this->info("Successfully created.");
+            return 0;
+        }
+
+        if ($this->argument('lms_type') === 'schoology') {
+            PlatformCreator::createLTI1p3PlatformSchoology(
+                $dataConnector,
+                $deployment_id,
+                $client_id);
             $this->info("Successfully created.");
             return 0;
         }

--- a/src/PlatformCreator.php
+++ b/src/PlatformCreator.php
@@ -113,4 +113,31 @@ class PlatformCreator
             $authorization_server_id
         );
     }
+    public static function createLTI1p3PlatformSchoology(
+        LTI\DataConnector\DataConnector $dataConnector,
+        $deployment_id,
+        $client_id
+    )
+    {
+        $platform_id = 'https://schoology.schoology.com';
+        $rsa_key = null;  // a public key is not required if a JKU is available
+        $signature_method = 'RS256';
+
+        $jku = 'https://lti-service.svc.schoology.com/lti-service/.well-known/jwks';
+        $authentication_url = 'https://lti-service.svc.schoology.com/lti-service/authorize-redirect';
+        $access_token_url = 'https://lti-service.svc.schoology.com/lti-service/access-token';
+        $authorization_server_id = null;  // defaults to the Access Token URL
+        self::createLTI1p3Platform(
+            $dataConnector,
+            $platform_id,
+            $deployment_id,
+            $client_id,
+            $jku,
+            $rsa_key,
+            $signature_method,
+            $authentication_url,
+            $access_token_url,
+            $authorization_server_id
+        );
+    }
 }


### PR DESCRIPTION
Instructions (which you may want to add to your wiki?)

How to retrieve your app's client ID on Schoology:

- Create your LTI 1.3 app in Schoology
- Go to your Schoology [apps page](https://app.schoology.com/apps/publisher)
- Next to your newly created app, click on Options, then API info
- Copy your Client ID

How to retrieve your deployment ID:

- Install your app
- Click Add to Organization
- Select appropriate boxes and cick submit
- Click Configure
- Copy the deployment ID